### PR TITLE
Fix(routes): Simplify routes for dashboard, tasks, and agency setup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy React app to GitHub Pages
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 permissions:

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -25,7 +25,7 @@ function App() {
 
         {/* Protected MainLayout routes */}
         <Route
-          path="/pages/dashboard.html"
+          path="/dashboard"
           element={<ProtectedRoute><MainLayout><DashboardPage /></MainLayout></ProtectedRoute>}
         />
         <Route
@@ -33,7 +33,7 @@ function App() {
           element={<ProtectedRoute><MainLayout><PropertiesPage /></MainLayout></ProtectedRoute>}
         />
         <Route
-          path="/pages/tasks.html"
+          path="/tasks"
           element={<ProtectedRoute><MainLayout><TasksPage /></MainLayout></ProtectedRoute>}
         />
         <Route
@@ -51,7 +51,7 @@ function App() {
 
         {/* Agency setup page route */}
         <Route
-          path="/pages/agency_setup_page.html"
+          path="/agency-setup"
           element={<ProtectedRoute><MainLayout><AgencySetupPage /></MainLayout></ProtectedRoute>}
         />
 

--- a/react-app/src/pages/SignInPage.jsx
+++ b/react-app/src/pages/SignInPage.jsx
@@ -74,14 +74,14 @@ const SignInPage = () => {
       const isAdmin = authedUser.app_metadata?.is_admin === true;
       if (!isAdmin) {
         localStorage.setItem('onboardingComplete', 'true');
-        navigate('/pages/tasks.html');
+        navigate('/tasks');
       } else {
         if (profile.has_company_set_up === false) {
           localStorage.removeItem('onboardingComplete');
           setIsLanguageModalOpen(true); // Then redirects to agency_setup_page via modal
         } else {
           localStorage.setItem('onboardingComplete', 'true');
-          navigate('/pages/dashboard.html');
+          navigate('/dashboard');
         }
       }
     } else if (profile) { // Profile exists but not verified by code
@@ -200,7 +200,7 @@ const SignInPage = () => {
     localStorage.setItem('preferredLang', lang); // For i18n.js
     // TODO: i18next.changeLanguage(lang);
     setIsLanguageModalOpen(false);
-    navigate('/pages/agency_setup_page.html'); // Navigate to agency setup
+    navigate('/agency-setup'); // Navigate to agency setup
     return { success: true, message: 'Language preference saved.' };
   };
 


### PR DESCRIPTION
This commit updates the React routing and navigation logic as a diagnostic step to address issues with GitHub Pages deployment.

Changes:
- In App.jsx, changed paths for DashboardPage, TasksPage, and AgencySetupPage to remove '.html' extensions and '/pages/' prefix (e.g., '/pages/dashboard.html' to '/dashboard').
- In SignInPage.jsx, updated navigation calls in handleSuccessfulSignIn and handleSaveLanguage to use these new simplified routes.

The goal is to determine if GitHub Pages' handling of direct .html paths was conflicting with the SPA routing, even with .nojekyll.