### PR TITLE
Refactor: Construct background image URL in variable

### DIFF
--- a/react-app/src/pages/SignInPage.jsx
+++ b/react-app/src/pages/SignInPage.jsx
@@ -302,9 +302,10 @@ const SignInPage = () => {
   );
 
   // Main Render
+  const bgImageUrl = `${import.meta.env.BASE_URL}assets/images/auth-background.png`;
   return (
     <>
-      <div className="col-lg-6 d-none d-lg-flex flex-column justify-content-center align-items-start p-5 text-white position-relative" style={{ backgroundImage: `url(${import.meta.env.BASE_URL}assets/images/auth-background.png)`, backgroundSize: 'cover', backgroundPosition: 'center' }}>
+      <div className="col-lg-6 d-none d-lg-flex flex-column justify-content-center align-items-start p-5 text-white position-relative" style={{ backgroundImage: `url(${bgImageUrl})`, backgroundSize: 'cover', backgroundPosition: 'center' }}>
         <div className="position-absolute top-0 start-0 w-100 h-100" style={{ backgroundColor: 'rgba(0, 0, 0, 0.5)' }}></div>
         <div className="position-relative"><h1 className="display-4 fw-bold mb-3">Property Hub</h1><p className="lead">Manage property maintenance tasks with ease. Schedule services, track tasks, and get real-time updates. All in one app!</p></div>
       </div>


### PR DESCRIPTION
This commit modifies how the background image URL in SignInPage.jsx is constructed, moving the \`\${import.meta.env.BASE_URL}\` concatenation into a separate variable before being used in the inline style.

This is an attempt to ensure Vite's build process correctly substitutes the BASE_URL, as direct usage in the style attribute was not reflecting the base path in the production build.