### PR TITLE
Fix: Comment out default button styles in index.css

### DIFF
--- a/react-app/src/index.css
+++ b/react-app/src/index.css
@@ -35,6 +35,7 @@ h1 {
   line-height: 1.1;
 }
 
+/*
 button {
   border-radius: 8px;
   border: 1px solid transparent;
@@ -55,6 +56,13 @@ button:focus-visible {
 }
 
 @media (prefers-color-scheme: light) {
+  button {
+    background-color: #f9f9f9;
+  }
+}
+*/
+
+@media (prefers-color-scheme: light) {
   :root {
     color: #213547;
     background-color: #ffffff;
@@ -62,7 +70,9 @@ button:focus-visible {
   a:hover {
     color: #747bff;
   }
+  /*
   button {
     background-color: #f9f9f9;
   }
+  */
 }


### PR DESCRIPTION
The generic 'button' element styles in Vite's default index.css were overriding Bootstrap's class-based button styling, preventing Bootstrap button styles (e.g., for .btn-primary) from applying correctly.

I've commented out the entire button styling block in index.css to allow Bootstrap styles to take precedence.