### PR TITLE
Fix: Comment out import of Vite's default index.css

### DIFF
--- a/react-app/src/main.jsx
+++ b/react-app/src/main.jsx
@@ -2,7 +2,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
-import './index.css'; // Default Vite global styles
+// import './index.css'; // Default Vite global styles
 import './css/style.css'; // Import custom global styles
 import { AuthProvider } from './context/AuthContext.jsx';
 


### PR DESCRIPTION
To isolate styling conflicts, this commit comments out the import of 'index.css' (Vite's default global styles) in main.jsx.

The intention is to rely solely on Bootstrap and custom styles (style.css) to determine if index.css was the primary source of styling issues.