### PR TITLE
Refactor: Standardize SPA routes and navigation links

### DIFF
--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -29,7 +29,7 @@ function App() {
           element={<ProtectedRoute><MainLayout><DashboardPage /></MainLayout></ProtectedRoute>}
         />
         <Route
-          path="/pages/properties.html"
+          path="/properties"
           element={<ProtectedRoute><MainLayout><PropertiesPage /></MainLayout></ProtectedRoute>}
         />
         <Route
@@ -37,18 +37,22 @@ function App() {
           element={<ProtectedRoute><MainLayout><TasksPage /></MainLayout></ProtectedRoute>}
         />
         <Route
-          path="/pages/staff.html"
+          path="/staff"
           element={<ProtectedRoute><MainLayout><StaffPage /></MainLayout></ProtectedRoute>}
         />
         <Route
-          path="/pages/notifications.html"
+          path="/notifications"
           element={<ProtectedRoute><MainLayout><NotificationsPage /></MainLayout></ProtectedRoute>}
         />
         <Route
-          path="/pages/account.html"
+          path="/account"
           element={<ProtectedRoute><MainLayout><AccountPage /></MainLayout></ProtectedRoute>}
         />
-
+        {/* Property Details Page Route - Placeholder */}
+        <Route
+          path="/property-details/:propertyId"
+          element={<ProtectedRoute><MainLayout><NotFoundPage /></MainLayout></ProtectedRoute>}
+        />
         {/* Agency setup page route */}
         <Route
           path="/agency-setup"

--- a/react-app/src/components/layout/Sidebar.jsx
+++ b/react-app/src/components/layout/Sidebar.jsx
@@ -10,17 +10,17 @@ const Sidebar = () => {
 
   // Links to hide for non-admins, based on original main.js updateSidebarForPermissions
   const nonAdminHiddenLinks = [
-    '/pages/dashboard.html',
-    '/pages/properties.html', // Assuming properties are admin-only view/manage
-    '/pages/staff.html'
+    '/dashboard',
+    '/properties', // Assuming properties are admin-only view/manage
+    '/staff'
   ];
 
   const navLinks = [
-    { path: '/pages/dashboard.html', icon: 'bi-speedometer2', labelKey: 'nav.dashboard', adminOnly: true },
-    { path: '/pages/properties.html', icon: 'bi-building', labelKey: 'nav.properties', adminOnly: true },
-    { path: '/pages/tasks.html', icon: 'bi-list-check', labelKey: 'nav.tasks', adminOnly: false },
-    { path: '/pages/staff.html', icon: 'bi-people-fill', labelKey: 'nav.staff', adminOnly: true },
-    { path: '/pages/notifications.html', icon: 'bi-bell-fill', labelKey: 'nav.notifications', adminOnly: false },
+    { path: '/dashboard', icon: 'bi-speedometer2', labelKey: 'nav.dashboard', adminOnly: true },
+    { path: '/properties', icon: 'bi-building', labelKey: 'nav.properties', adminOnly: true },
+    { path: '/tasks', icon: 'bi-list-check', labelKey: 'nav.tasks', adminOnly: false },
+    { path: '/staff', icon: 'bi-people-fill', labelKey: 'nav.staff', adminOnly: true },
+    { path: '/notifications', icon: 'bi-bell-fill', labelKey: 'nav.notifications', adminOnly: false },
   ];
 
   return (

--- a/react-app/src/components/layout/TopBar.jsx
+++ b/react-app/src/components/layout/TopBar.jsx
@@ -27,19 +27,29 @@ const TopBar = () => {
 
   useEffect(() => {
     const pathTitleMapping = {
-      '/pages/dashboard.html': 'Dashboard',
-      '/pages/properties.html': 'Properties',
-      '/pages/tasks.html': 'Tasks',
-      '/pages/staff.html': 'Staff',
-      '/pages/notifications.html': 'Notifications',
-      '/pages/account.html': 'Account Settings',
-      '/pages/agency_setup_page.html': 'Agency Setup'
+      '/dashboard': 'Dashboard',
+      '/properties': 'Properties',
+      '/tasks': 'Tasks',
+      '/staff': 'Staff',
+      '/notifications': 'Notifications',
+      '/account': 'Account Settings',
+      '/agency-setup': 'Agency Setup',
+      '/property-details/:propertyId': 'Property Details'
     };
-    setPageTitle(pathTitleMapping[location.pathname] || 'Property Hub');
+    // Match dynamic routes like /property-details/:propertyId
+    let title = 'Property Hub';
+    for (const key in pathTitleMapping) {
+      const regex = new RegExp(`^${key.replace(/:\w+/g, '[^/]+')}$`);
+      if (regex.test(location.pathname)) {
+        title = pathTitleMapping[key];
+        break;
+      }
+    }
+    setPageTitle(title);
   }, [location.pathname]);
 
   // Access Denied Modal Logic (remains the same as it relies on Bootstrap JS)
-  const adminOnlyPages = ['/pages/dashboard.html', '/pages/properties.html', '/pages/staff.html'];
+  const adminOnlyPages = ['/dashboard', '/properties', '/staff'];
   // Use isAdmin from context now
   const isAccessingAdminPageAsNonAdmin = user && !isAdmin && adminOnlyPages.includes(location.pathname);
 
@@ -61,7 +71,8 @@ const TopBar = () => {
     }
     const redirectToTasksBtn = document.getElementById('redirectToTasksBtn');
     if(redirectToTasksBtn) {
-        redirectToTasksBtn.onclick = () => { navigate('/pages/tasks.html'); }; // Use React Router navigate
+        // This button might not exist in the new TopBar structure, but if it does, update its navigation
+        redirectToTasksBtn.onclick = () => { navigate('/tasks'); }; // Use React Router navigate
     }
   }, [isAccessingAdminPageAsNonAdmin, navigate]);
 
@@ -81,14 +92,14 @@ const TopBar = () => {
         <span data-i18n={`${pageTitle.toLowerCase().replace(' ', '')}Page.header`}>{pageTitle}</span>
       </div>
       <div className="top-bar-icons d-flex align-items-center">
-        <Link to="/pages/notifications.html"><i className="bi bi-bell-fill"></i></Link>
+        <Link to="/notifications"><i className="bi bi-bell-fill"></i></Link>
         <div className="dropdown">
           <a className="dropdown-toggle dropdown-toggle-no-caret" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
             <i className="bi bi-person-gear"></i>
           </a>
           <ul className="dropdown-menu dropdown-menu-end">
             <li>
-              <Link className="dropdown-item" to="/pages/account.html">
+              <Link className="dropdown-item" to="/account">
                 <i className="bi bi-gear-fill me-2"></i>Account Settings
               </Link>
             </li>

--- a/react-app/src/pages/DashboardPage.jsx
+++ b/react-app/src/pages/DashboardPage.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext'; // To ensure user is loaded, though ProtectedRoute handles auth
 import { supabase } from '../supabaseClient';
 
@@ -109,9 +110,9 @@ const DashboardPage = () => {
               <div className="card-body">
                 <div className="d-flex justify-content-between align-items-center mb-3">
                   <h5 className="card-title mb-0" data-i18n="dashboardPage.cardProperties.title">Properties</h5>
-                  {/* <Link to="/pages/properties.html" className="card-link" data-i18n="dashboardPage.cardProperties.link">View Properties</Link> */}
+                  {/* <Link to="/properties" className="card-link" data-i18n="dashboardPage.cardProperties.link">View Properties</Link> */}
                   {/* Replaced with simple <a> for now if Link causes issues before full page setup */}
-                  <a href="/maintrixx/pages/properties.html" className="card-link" data-i18n="dashboardPage.cardProperties.link">View Properties</a>
+                  <Link to="/properties" className="card-link" data-i18n="dashboardPage.cardProperties.link">View Properties</Link>
 
                 </div>
                 {loadingProps && <p data-i18n="dashboardPage.loading">Loading...</p>}
@@ -131,7 +132,7 @@ const DashboardPage = () => {
               <div className="card-body">
                 <div className="d-flex justify-content-between align-items-center mb-3">
                   <h5 className="card-title mb-0" data-i18n="dashboardPage.cardTasks.title">Tasks</h5>
-                  <a href="/maintrixx/pages/tasks.html" className="card-link" data-i18n="dashboardPage.cardTasks.link">View Tasks</a>
+                  <Link to="/tasks" className="card-link" data-i18n="dashboardPage.cardTasks.link">View Tasks</Link>
                 </div>
                 {loadingTasks && <p data-i18n="dashboardPage.loading">Loading...</p>}
                 {errorTasks && <p className="text-danger" data-i18n="dashboardPage.error">Error: {errorTasks}</p>}
@@ -156,7 +157,7 @@ const DashboardPage = () => {
               <div className="card-body">
                 <div className="d-flex justify-content-between align-items-center mb-3">
                   <h5 className="card-title mb-0" data-i18n="dashboardPage.cardStaff.title">Staff</h5>
-                  <a href="/maintrixx/pages/staff.html" className="card-link" data-i18n="dashboardPage.cardStaff.link">View Staff</a>
+                  <Link to="/staff" className="card-link" data-i18n="dashboardPage.cardStaff.link">View Staff</Link>
                 </div>
                 {loadingStaff && <p data-i18n="dashboardPage.loading">Loading...</p>}
                 {errorStaff && <p className="text-danger" data-i18n="dashboardPage.error">Error: {errorStaff}</p>}

--- a/react-app/src/pages/PropertiesPage.jsx
+++ b/react-app/src/pages/PropertiesPage.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useCallback } from 'react';
 import { supabase } from '../supabaseClient';
 import { useAuth } from '../context/AuthContext'; // To check admin role for CRUD
 import AddEditPropertyModal from '../components/modals/AddEditPropertyModal';
-// import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 const ITEMS_PER_PAGE = 8;
 
@@ -143,7 +143,7 @@ const PropertiesPage = () => {
                   <p className="card-text text-muted small">
                     {property.address_street || 'N/A'}, {property.address_city || 'N/A'}
                   </p>
-                  <a href={`/maintrixx/pages/property-details.html?id=${property.id}`} className="text-primary small mt-auto align-self-start">View Details</a>
+                  <Link to={`/property-details/${property.id}`} className="text-primary small mt-auto align-self-start">View Details</Link>
                 </div>
                 {isAdmin && ( // Show Edit/Delete only to admins
                   <div className="card-footer bg-light d-flex justify-content-end">


### PR DESCRIPTION
This commit implements consistent, simplified routes for the React application:
- Updated routes in App.jsx to use paths like /dashboard, /properties, /tasks, /staff, /notifications, /account, and /agency-setup, removing the old /pages/ prefix and .html suffixes.
- Added a placeholder route for /property-details/:propertyId.
- Updated all <Link to=""...> props and navigate() calls in Sidebar.jsx, TopBar.jsx, DashboardPage.jsx, and PropertiesPage.jsx to use these new standardized route paths.
- Updated path mappings for page titles and access control checks in TopBar.jsx to reflect the new routes.

This ensures that internal navigation uses SPA best practices and maintains consistency across the application.