### PR TITLE
Fix: Implement SPA fallback for GitHub Pages refresh/direct navigation

### DIFF
--- a/react-app/index.html
+++ b/react-app/index.html
@@ -5,6 +5,53 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>
+    <script type="text/javascript">
+      (function() {
+        const routePath = sessionStorage.getItem('spa_redirect_path');
+        if (routePath) {
+          const search = sessionStorage.getItem('spa_redirect_search') || '';
+          const hash = sessionStorage.getItem('spa_redirect_hash') || '';
+
+          sessionStorage.removeItem('spa_redirect_path');
+          sessionStorage.removeItem('spa_redirect_search');
+          sessionStorage.removeItem('spa_redirect_hash');
+
+          // The `routePath` from 404.html is relative to the app's base (e.g., "/dashboard").
+          // `window.location.pathname` when index.html loads after redirect from 404.html will be the base path (e.g., "/maintrixx/").
+          // We want to replace history to be 'basePath + routePath'.
+          // `history.replaceState` takes a path relative to the domain.
+
+          const basePath = '/maintrixx'; // This MUST match your vite.config.js base
+
+          // Ensure basePath ends with a slash if it's not empty, and routePath doesn't start with one
+          // to avoid double slashes or missing slashes.
+          let normalizedBasePath = basePath;
+          if (normalizedBasePath && !normalizedBasePath.endsWith('/')) {
+            normalizedBasePath += '/';
+          }
+          if (normalizedBasePath === '/') { // If base is just root, don't add leading slash to routePath if it's already there
+              normalizedBasePath = '';
+          }
+
+          const normalizedRoutePath = routePath.startsWith('/') ? routePath.substring(1) : routePath;
+
+          let fullPath = normalizedBasePath + normalizedRoutePath + search + hash;
+
+          // If the original path was just the base path (e.g. /maintrixx/ which becomes routePath='/'),
+          // ensure we don't end up with /maintrixx//
+          if (routePath === '/' && fullPath.endsWith('//')) {
+              fullPath = fullPath.substring(0, fullPath.length -1);
+          }
+
+
+          if (window.location.pathname !== fullPath.split('?')[0].split('#')[0] ||
+              window.location.search !== search ||
+              window.location.hash !== hash) {
+            window.history.replaceState(null, '', fullPath);
+          }
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/react-app/public/404.html
+++ b/react-app/public/404.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Single Page App Redirect</title>
+    <script>
+      // Store the full path that led to the 404 page.
+      // It should include the base path, e.g., /maintrixx/dashboard
+      var path = window.location.pathname;
+      var search = window.location.search;
+      var hash = window.location.hash;
+
+      // The base path of your application, as configured in vite.config.js
+      var basePath = '/maintrixx'; // Make sure this matches your vite.config.js base
+
+      // Remove the basePath from the start of the path, if present,
+      // because React Router expects paths relative to the application root.
+      var routePath = path;
+      if (path.startsWith(basePath)) {
+        routePath = path.substring(basePath.length);
+      }
+
+      // If routePath is empty, it means we are at the base (e.g. /maintrixx/ itself was 404'd, unlikely but handle)
+      // or if it was /maintrixx, then routePath becomes "" which means "/" for the router.
+      if (routePath === '' || routePath === '/') {
+        routePath = '/'; // Default to root route
+      }
+
+
+      // Store the intended route path, search params, and hash for index.html to pick up.
+      sessionStorage.setItem('spa_redirect_path', routePath);
+      sessionStorage.setItem('spa_redirect_search', search);
+      sessionStorage.setItem('spa_redirect_hash', hash);
+
+      // Redirect to the index.html at the base of your site.
+      // The href should be to the base path, which serves index.html.
+      window.location.replace(basePath + (basePath.endsWith('/') ? '' : '/'));
+
+    </script>
+  </head>
+  <body>
+    <!-- Optional: a message for users if JavaScript is disabled or redirect fails -->
+    <p>If you are not redirected automatically, please navigate to the <a href="/maintrixx/">home page</a>.</p>
+  </body>
+</html>


### PR DESCRIPTION
This commit adds the necessary files and scripts to handle client-side routing correctly when refreshing or directly navigating to sub-routes on GitHub Pages.

Changes:
- Created `react-app/public/404.html`: This page captures the intended URL path that caused a 404, stores it in sessionStorage, and redirects to the root index.html of the SPA.
- Modified `react-app/index.html`: Added a script in the <head> to check for the stored path from sessionStorage on page load. If found, it uses history.replaceState() to update the URL to the correct deep link before React Router initializes. This allows the SPA to load the correct route.

This should resolve 404 errors when refreshing pages on the deployed GitHub Pages site.