### PR TITLE
Fix: Add Bootstrap Icons CSS for sidebar icons

### DIFF
--- a/react-app/package-lock.json
+++ b/react-app/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.50.0",
         "bootstrap": "^5.3.6",
+        "bootstrap-icons": "^1.13.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.2"
@@ -1490,6 +1491,21 @@
       "peerDependencies": {
         "@popperjs/core": "^2.11.8"
       }
+    },
+    "node_modules/bootstrap-icons": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.13.1.tgz",
+      "integrity": "sha512-ijombt4v6bv5CLeXvRWKy7CuM3TRTuPEuGaGKvTV5cz65rQSY8RQ2JcHt6b90cBBAC7s8fsf2EkQDldzCoXUjw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ]
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.50.0",
     "bootstrap": "^5.3.6",
+    "bootstrap-icons": "^1.13.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.2"

--- a/react-app/src/main.jsx
+++ b/react-app/src/main.jsx
@@ -1,4 +1,5 @@
 import 'bootstrap/dist/css/bootstrap.min.css';
+import 'bootstrap-icons/font/bootstrap-icons.css';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';


### PR DESCRIPTION
The sidebar icons were missing because the Bootstrap Icons CSS was not being included in the application.

This commit:
- Installs the 'bootstrap-icons' npm package.
- Imports 'bootstrap-icons/font/bootstrap-icons.css' in main.jsx to make the icon font and associated styles available.